### PR TITLE
changing schema generation method to use pyxb "API"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 MANIFEST
 build/
 dist/
+*.swp

--- a/ismrmrd/__init__.py
+++ b/ismrmrd/__init__.py
@@ -3,4 +3,5 @@ from .acquisition import *
 from .image import *
 from .hdf5 import Dataset
 
-#__all__ = ["constatns", "acquisition", "image", "xsd", "hdf5"]
+import xsd
+__all__ = ['xsd']


### PR DESCRIPTION
Simulating a call to `pyxbgen` tool by forming a list of command-line arguments and generating the schema using the same code used by `pyxbgen`.