### PR TITLE
adding basic Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python:
+- '2.7'
+before_install:
+- sudo apt-get update
+- sudo apt-get install libhdf5-serial-dev h5utils
+- pip install Cython
+- pip install numpy
+- pip install h5py
+- pip install PyXB
+install:
+- python setup.py build
+script: python setup.py test
+deploy:
+  provider: pypi
+  user: naegelejd
+  on:
+    tags: true
+  password:
+    secure: bxGtr0gxbYWWhVdXRB0j9BxebI4dpMhX16IpRdBFvCJ2fcN5UICDn5jFVsWZiFV5XcUpnS6uYo9XreN+nDXcatLfTIf8u8PkpuGj31ooSWjNc1PGAbPCFK+RdGadPnT8OeiIISwmn94UjRPjTBbrcW/5gdVKykJiFW2kr/JuPrQ=

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def generate_schema(schema_filename, module_name, output_directory):
 
 setup(
     name='ismrmrd',
-    version='1.2.2',
+    version='1.2.3',
     author='ISMRMRD Developers',
     author_email='ismrmrd@googlegroups.com',
     description='Python implementation of the ISMRMRD',


### PR DESCRIPTION
This allows us to:

1. Use Travis to run some basic unit tests
1. Upload releases to PyPi when we tag a new version

One notable issue is that PyPi won't allow you to release the same "version" twice, or even re-upload the same file if you need to fix any small mistakes. They require entirely new releases (e.g. a point release, release candidate, etc.) to be uploaded each time.