### PR TITLE
Fixed issue where Image.from_array would generate transposed matrix_size header field. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def generate_schema(schema_filename, config_filename, outloc  ):
 
 setup(
     name='ismrmrd',
-    version='1.9.2',
+    version='1.9.3',
     author='ISMRMRD Developers',
     author_email='dchansen@gradientsoftware.net',
     description='Python implementation of the ISMRMRD',


### PR DESCRIPTION
Fixed issue where image matrix_size would be transposed if caller used 'transpose=False' flag.