### PR TITLE
Reverting license change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,10 +58,10 @@ long_description = (this_directory / "README").read_text()
 
 setup(
     name='ismrmrd',
-    version='1.12.1',
+    version='1.12.2',
     author='ISMRMRD Developers',
     description='Python implementation of the ISMRMRD',
-    license='MIT',
+    license='Public Domain',
     keywords='ismrmrd',
     url='https://ismrmrd.github.io',
     long_description = long_description,


### PR DESCRIPTION
Previous change of license designation to MIT is causing problems for pypi so we will revert to "Public Domain" until we figure out what the right thing is to do. Also bumping patch version here.