### PR TITLE
Fix for conda package build on macOS

### DIFF
--- a/.github/workflows/ismrmrd_python_conda.yml
+++ b/.github/workflows/ismrmrd_python_conda.yml
@@ -10,7 +10,7 @@ jobs:
   build-conda-packages:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-python setup.py install
+pip install .

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ long_description = (this_directory / "README").read_text()
 
 setup(
     name='ismrmrd',
-    version='1.12.3',
+    version='1.12.4',
     author='ISMRMRD Developers',
     description='Python implementation of the ISMRMRD',
     license='Public Domain',

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         'Operating System :: OS Independent',
         'Topic :: Scientific/Engineering :: Medical Science Apps.'
         ],
-    install_requires=['xsdata>=22.2', 'numpy', 'h5py>=2.3'],
+    install_requires=['xsdata>=22.2', 'numpy>=1.22.0', 'h5py>=2.3'],
     setup_requires=['nose>=1.0', 'xsdata[cli]>=22.2', 'jinja2 >= 2.11'],
     test_suite='nose.collector',
     cmdclass={'build_py':my_build_py}

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -169,7 +169,7 @@ def test_initialization_sets_nonzero_version():
 
     acquisition = ismrmrd.Acquisition.from_array(common.create_random_data())
 
-    assert acquisition.version is not 0, \
+    assert acquisition.version != 0, \
         "Default acquisition version should not be zero."
 
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -67,7 +67,7 @@ def test_initialization_sets_nonzero_version():
 
     image = ismrmrd.Image.from_array(common.create_random_array((128, 128), dtype=np.float32))
 
-    assert image.version is not 0, \
+    assert image.version != 0, \
         "Default image version should not be zero."
 
 
@@ -134,7 +134,7 @@ def test_initialization_with_2d_image():
     assert np.array_equal(image_data.transpose(), image.data.squeeze()), \
         "Image data does not match data used to initialize image."
 
-    assert image.channels is 1, \
+    assert image.channels == 1, \
         "Unexpected number of channels: {}".format(image.channels)
 
     assert image.matrix_size == (1, 64, 128), \
@@ -150,7 +150,7 @@ def test_initialization_with_3d_image():
     assert np.array_equal(image_data.transpose(), image.data.squeeze()), \
         "Image data does not match data used to initialize image."
 
-    assert image.channels is 1, \
+    assert image.channels == 1, \
         "Unexpected number of channels: {}".format(image.channels)
 
     assert image.matrix_size == (32, 64, 128), \
@@ -166,7 +166,7 @@ def test_initialization_with_3d_image_and_channels():
     assert np.array_equal(image_data.transpose(), image.data.squeeze()), \
         "Image data does not match data used to initialize image."
 
-    assert image.channels is 16, \
+    assert image.channels == 16, \
         "Unexpected number of channels: {}".format(image.channels)
 
     assert image.matrix_size == (32, 64, 128), \

--- a/tests/test_waveform.py
+++ b/tests/test_waveform.py
@@ -31,7 +31,7 @@ def test_initialization_sets_nonzero_version():
 
     waveform = common.create_random_waveform()
 
-    assert waveform.version is not 0, \
+    assert waveform.version != 0, \
         "Default acquisition version should not be zero."
 
 


### PR DESCRIPTION
Prior to this, conda package building and testing would fail on macOS.

On macOS, the conda package would be created, the .egg file copied into ${CONDA_PREFIX}/lib/python/site-packages, but **not** being unzipped.  Therefore, the library would not get created.

This PR should address this issue.