### PR TITLE
Make Dataset a Context Manager.

### DIFF
--- a/ismrmrd/hdf5.py
+++ b/ismrmrd/hdf5.py
@@ -158,7 +158,13 @@ class Dataset(object):
             self.close()
         except:
             pass
-        
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     @property
     def _dataset(self):
         if self._dataset_name not in self._file:
@@ -167,7 +173,7 @@ class Dataset(object):
 
     def list(self):
         return self._dataset.keys()
-    
+
     def close(self):
         self._file.close()
 


### PR DESCRIPTION
We would like to be able to use the  `Dataset ` class in a with statement, i.e.

```
with Dataset(...) as ds:
   dowork
```
   
   instead of
  ```
 ds=Dataset()
 dowork
 ds.close() # we tend to forget this line..
```

This is a simple 4 line change to enable this, similar to how it is done for the `File `class
