### PR TITLE
Fix compatibility with xsdata 26.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 h5py==3.14.0
 pytest==8.4.1
 numpy==2.3.2
-xsdata==25.7
+xsdata==26.1

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ class GenerateSchemaCommand(Command):
         import sys
         import subprocess
         # subpackage_name = 'ismrmrdschema'
-        args = [sys.executable, '-m', 'xsdata', str(schema_filename), '--config', str(config_filename), '--package', subpackage_name]
+        args = [sys.executable, '-m', 'xsdata', 'generate', str(schema_filename), '--config', str(config_filename), '--package', subpackage_name]
         subprocess.run(args)
         self.fix_init_file(subpackage_name, f"{subpackage_name}/__init__.py")
         destination = os.path.join(outdir, subpackage_name)
@@ -66,7 +66,7 @@ class GenerateSchemaCommand(Command):
         shutil.move(subpackage_name, destination)
 
 setup(
-    version='1.14.2',
+    version='1.14.3',
     packages=find_packages(),
     cmdclass={
         'generate_schema': GenerateSchemaCommand


### PR DESCRIPTION
With the release of [xsdata 26.1](https://xsdata.readthedocs.io/en/v26.1/changelog/), it is necessary to explicitly specify the command `generate` when using xsdata to build schema as described in https://github.com/tefra/xsdata/pull/1128.