### PR TITLE
Add _layout_ for ctypes to resolve warning introduced in Python 3.14

### DIFF
--- a/ismrmrd/acquisition.py
+++ b/ismrmrd/acquisition.py
@@ -11,6 +11,7 @@ from . import decorators
 
 class EncodingCounters(EqualityMixin, ctypes.Structure):
     _pack_ = 2
+    _layout_ = "ms"
     _fields_ = [("kspace_encode_step_1", ctypes.c_uint16),
                 ("kspace_encode_step_2", ctypes.c_uint16),
                 ("average", ctypes.c_uint16),
@@ -35,6 +36,7 @@ class EncodingCounters(EqualityMixin, ctypes.Structure):
 
 class AcquisitionHeader(FlagsMixin, ChannelMaskMixin, EqualityMixin, ctypes.Structure):
     _pack_ = 2
+    _layout_ = "ms"
     _fields_ = [("version", ctypes.c_uint16),
                 ("flags", ctypes.c_uint64),
                 ("measurement_uid", ctypes.c_uint32),

--- a/ismrmrd/image.py
+++ b/ismrmrd/image.py
@@ -44,6 +44,7 @@ def get_data_type_from_dtype(dtype):
 # Image Header
 class ImageHeader(FlagsMixin, EqualityMixin, ctypes.Structure):
     _pack_ = 2
+    _layout_ = "ms"
     _fields_ = [("version", ctypes.c_uint16),
                 ("data_type", ctypes.c_uint16),
                 ("flags", ctypes.c_uint64),

--- a/ismrmrd/waveform.py
+++ b/ismrmrd/waveform.py
@@ -9,6 +9,7 @@ from . import decorators
 
 class WaveformHeader(FlagsMixin, EqualityMixin, ctypes.Structure):
     _pack_ = 8
+    _layout_ = "ms"
     _fields_ = [("version", ctypes.c_uint16),
                 ("flags", ctypes.c_uint64),
                 ("measurement_uid", ctypes.c_uint32),


### PR DESCRIPTION
Python 3.14 introduces a [`_layout_`](https://docs.python.org/3.15/library/ctypes.html#ctypes.Structure._layout_) property for ctypes.  Setting the `_pack_` property without `_layout_` produces a warning in 3.14 and will result in an error in 3.19.  This change does not affect Python <3.14

Warning message without this fix:
```
>>> import ismrmrd
/opt/code/ismrmrd-python/ismrmrd/image.py:45: DeprecationWarning: Due to '_pack_', the 'ImageHeader' Structure will use memory layout compatible with MSVC (Windows). If this is intended, set _layout_ to 'ms'. The implicit default is deprecated and slated to become an error in Python 3.19.
```